### PR TITLE
ci: disable changelog job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,12 +15,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Update CHANGELOG
-        id: changelog
-        uses: requarks/changelog-action@v1
-        with:
-          token: ${{ github.token }}
-          tag: ${{ github.ref_name }}
+      # - name: Update CHANGELOG
+      #   id: changelog
+      #   uses: requarks/changelog-action@v1
+      #   with:
+      #     token: ${{ github.token }}
+      #     tag: ${{ github.ref_name }}
         
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyhgvs2"
-version = "3.0.2"
+version = "3.0.3"
 description = "Fork of pyhgvs"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -126,7 +126,7 @@ wheels = [
 
 [[package]]
 name = "pyhgvs2"
-version = "3.0.2"
+version = "3.0.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
disables changelog job as it was causing the deployment pipeline to fail.
This will be re-enabled in #16